### PR TITLE
Fixed watchlist crash and final polish

### DIFF
--- a/VRC Companion.xcodeproj/xcuserdata/douglas.jiang.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/VRC Companion.xcodeproj/xcuserdata/douglas.jiang.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -48,8 +48,8 @@
             endingColumnNumber = "9223372036854775807"
             startingLineNumber = "27"
             endingLineNumber = "27"
-            landmarkName = "unknown"
-            landmarkType = "0">
+            landmarkName = "APIRequest"
+            landmarkType = "21">
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy

--- a/VRC Companion/Views/ContentView.swift
+++ b/VRC Companion/Views/ContentView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct ContentView: View {
     /// The shared global state, holds the single source of truth of the application.
@@ -46,5 +47,18 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView()
+    do {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let schema = Schema([
+            TeamInfoModel.self,
+            LocationModel.self,
+            IDInfoModel.self
+        ])
+        let container = try ModelContainer(for: schema, configurations: config)
+        return ContentView()
+            .environment(StateController())
+            .modelContainer(container)
+    } catch {
+        fatalError("Could not create ModelContainer: \(error)")
+    }
 }

--- a/VRC Companion/Views/Upcoming/Main Screen/LargeMatchRow.swift
+++ b/VRC Companion/Views/Upcoming/Main Screen/LargeMatchRow.swift
@@ -22,7 +22,10 @@ struct LargeMatchRow: View {
                 Spacer()
                 if let time = match.scheduledTime {
                     // Displays the "queue now" text if the match is scheduled to begin in the next 5 minutes. Otherwise displays the time.
-                    if time.timeIntervalSinceNow.isLess(than: 300) {
+                    if time.timeIntervalSinceNow.isLess(than: 0) {
+                        Text(time.formatted(date: .omitted, time: .shortened))
+                            .foregroundStyle(.secondary)
+                    } else if time.timeIntervalSinceNow.isLess(than: 300) {
                         Text("Queue Now")
                             .foregroundStyle(.secondary)
                             .fontWeight(.medium)


### PR DESCRIPTION
The contents of this PR is minimal, however important.

1. The watchlist deletion crash has been fixed. Now the application won't crash when you swipe to *Unwatch* a team.
2. Added preview model container in ContentView so all model operations can be tested in Live Preview.
3. In Upcoming, the larger appearance of a match row will now show the aboslute time of the match after it has begun.

Hopefully this is the last PR before task submission.