### PR TITLE
Update MatchModel to new API scheme

### DIFF
--- a/VRC Companion.xcodeproj/xcuserdata/douglas.jiang.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/VRC Companion.xcodeproj/xcuserdata/douglas.jiang.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -39,22 +39,6 @@
       <BreakpointProxy
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
-            uuid = "FB230666-D09B-4B4F-AA03-C2CAAB3ED58C"
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "VRC Companion/Models/NetworkRequests.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "27"
-            endingLineNumber = "27"
-            landmarkName = "APIRequest"
-            landmarkType = "21">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
             uuid = "C89DE1DB-74A7-4E3B-B377-8EA764E1415E"
             shouldBeEnabled = "No"
             ignoreCount = "0"

--- a/VRC Companion/Models/MatchModels.swift
+++ b/VRC Companion/Models/MatchModels.swift
@@ -23,6 +23,8 @@ struct MatchModel: Identifiable {
     
     let alliances: [AllianceModel]
     
+    let lastUpdated: Date?
+    
     enum MatchSides {
         case team
         case opposition
@@ -71,6 +73,7 @@ extension MatchModel: Decodable {
         case matchNum = "matchnum"
         case scheduledTime = "scheduled"
         case startedTime = "started"
+        case lastUpdated = "updated_at"
         case id, name, event, division, round, instance, field, scored, alliances
     }
     
@@ -91,6 +94,7 @@ extension MatchModel: Decodable {
         scored = try container.decode(Bool.self, forKey: .scored)
         
         alliances = try container.decode([AllianceModel].self, forKey: .alliances)
+        lastUpdated = try container.decodeIfPresent(Date.self, forKey: .lastUpdated)
     }
 }
 

--- a/VRC Companion/Models/MatchModels.swift
+++ b/VRC Companion/Models/MatchModels.swift
@@ -19,7 +19,6 @@ struct MatchModel: Identifiable {
     let scheduledTime: Date?
     let startedTime: Date?
     let field: String?
-    let session: Int
     let scored: Bool
     
     let alliances: [AllianceModel]
@@ -72,7 +71,7 @@ extension MatchModel: Decodable {
         case matchNum = "matchnum"
         case scheduledTime = "scheduled"
         case startedTime = "started"
-        case id, name, event, division, round, instance, field, session, scored, alliances
+        case id, name, event, division, round, instance, field, scored, alliances
     }
     
     init(from decoder: Decoder) throws {
@@ -89,7 +88,6 @@ extension MatchModel: Decodable {
         scheduledTime = try container.decodeIfPresent(Date.self, forKey: .scheduledTime)
         startedTime = try container.decodeIfPresent(Date.self, forKey: .startedTime)
         field = try container.decodeIfPresent(String.self, forKey: .field)
-        session = try container.decode(Int.self, forKey: .session)
         scored = try container.decode(Bool.self, forKey: .scored)
         
         alliances = try container.decode([AllianceModel].self, forKey: .alliances)

--- a/VRC Companion/Preview Content/SiegeNationalsMatchlist.json
+++ b/VRC Companion/Preview Content/SiegeNationalsMatchlist.json
@@ -31,7 +31,6 @@
             "scheduled": "2023-12-01T18:30:00-05:00",
             "started": "2023-12-01T18:31:52-05:00",
             "field": "IFI",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #1",
             "alliances": [
@@ -79,7 +78,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158710,
@@ -99,7 +99,6 @@
             "scheduled": "2023-12-01T20:12:00-05:00",
             "started": "2023-12-01T20:06:57-05:00",
             "field": "SAPN",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #18",
             "alliances": [
@@ -147,7 +146,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158714,
@@ -167,7 +167,6 @@
             "scheduled": "2023-12-01T21:06:00-05:00",
             "started": "2023-12-01T21:06:11-05:00",
             "field": "SAPN",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #22",
             "alliances": [
@@ -215,7 +214,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158727,
@@ -235,7 +235,6 @@
             "scheduled": "2023-12-01T22:24:00-05:00",
             "started": "2023-12-01T22:22:31-05:00",
             "field": "IFI",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #35",
             "alliances": [
@@ -283,7 +282,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158735,
@@ -303,7 +303,6 @@
             "scheduled": "2023-12-01T23:12:00-05:00",
             "started": "2023-12-01T23:10:30-05:00",
             "field": "IFI",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #43",
             "alliances": [
@@ -351,7 +350,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158739,
@@ -371,7 +371,6 @@
             "scheduled": "2023-12-01T23:36:00-05:00",
             "started": "2023-12-01T23:35:42-05:00",
             "field": "IFI",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #47",
             "alliances": [
@@ -419,7 +418,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158752,
@@ -439,7 +439,6 @@
             "scheduled": "2023-12-02T17:54:00-05:00",
             "started": "2023-12-02T17:54:31-05:00",
             "field": "SAPN",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #60",
             "alliances": [
@@ -487,7 +486,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158756,
@@ -507,7 +507,6 @@
             "scheduled": "2023-12-02T18:18:00-05:00",
             "started": "2023-12-02T18:31:58-05:00",
             "field": "SAPN",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #64",
             "alliances": [
@@ -555,7 +554,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158765,
@@ -575,7 +575,6 @@
             "scheduled": "2023-12-02T19:12:00-05:00",
             "started": "2023-12-02T19:34:57-05:00",
             "field": "IFI",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #73",
             "alliances": [
@@ -623,7 +622,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158782,
@@ -643,7 +643,6 @@
             "scheduled": null,
             "started": "2023-12-02T23:10:37-05:00",
             "field": "IFI",
-            "session": 1,
             "scored": false,
             "name": "QF #1-1",
             "alliances": [
@@ -691,7 +690,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158786,
@@ -711,7 +711,6 @@
             "scheduled": null,
             "started": "2023-12-02T23:40:19-05:00",
             "field": "IFI",
-            "session": 1,
             "scored": false,
             "name": "SF #1-1",
             "alliances": [
@@ -759,7 +758,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158788,
@@ -779,7 +779,6 @@
             "scheduled": null,
             "started": "2023-12-03T00:16:39-05:00",
             "field": "SAPN",
-            "session": 1,
             "scored": false,
             "name": "Final #1-1",
             "alliances": [
@@ -827,7 +826,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158789,
@@ -847,7 +847,6 @@
             "scheduled": null,
             "started": "2023-12-03T00:30:12-05:00",
             "field": null,
-            "session": 1,
             "scored": false,
             "name": "Final #1-2",
             "alliances": [
@@ -895,7 +894,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         },
         {
             "id": 61158774,
@@ -915,7 +915,6 @@
             "scheduled": null,
             "started": "2023-12-02T22:34:15-05:00",
             "field": "IFI",
-            "session": 1,
             "scored": false,
             "name": "R16 #1-1",
             "alliances": [
@@ -963,7 +962,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2023-12-05T01:03:32-05:00"
         }
     ]
 }

--- a/VRC Companion/Preview Content/SiegeWorldsMatchlist.json
+++ b/VRC Companion/Preview Content/SiegeWorldsMatchlist.json
@@ -31,7 +31,6 @@
             "scheduled": null,
             "started": null,
             "field": "NASA",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #6",
             "alliances": [
@@ -79,7 +78,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2024-04-27T19:54:56-04:00"
         },
         {
             "id": 81658890,
@@ -99,7 +99,6 @@
             "scheduled": null,
             "started": null,
             "field": "NASA",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #30",
             "alliances": [
@@ -147,7 +146,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2024-04-27T19:54:56-04:00"
         },
         {
             "id": 81658911,
@@ -167,7 +167,6 @@
             "scheduled": null,
             "started": null,
             "field": "NASA",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #51",
             "alliances": [
@@ -215,7 +214,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2024-04-27T19:54:56-04:00"
         },
         {
             "id": 81658925,
@@ -235,7 +235,6 @@
             "scheduled": null,
             "started": null,
             "field": "NGF",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #65",
             "alliances": [
@@ -283,7 +282,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2024-04-27T19:54:56-04:00"
         },
         {
             "id": 81658961,
@@ -303,7 +303,6 @@
             "scheduled": null,
             "started": null,
             "field": "NGF",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #101",
             "alliances": [
@@ -351,7 +350,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2024-04-27T19:54:56-04:00"
         },
         {
             "id": 81658978,
@@ -371,7 +371,6 @@
             "scheduled": null,
             "started": null,
             "field": "Eaton",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #118",
             "alliances": [
@@ -419,7 +418,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2024-04-27T19:54:56-04:00"
         },
         {
             "id": 81658995,
@@ -439,7 +439,6 @@
             "scheduled": null,
             "started": null,
             "field": "NASA",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #135",
             "alliances": [
@@ -487,7 +486,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2024-04-27T19:54:56-04:00"
         },
         {
             "id": 81659012,
@@ -507,7 +507,6 @@
             "scheduled": null,
             "started": null,
             "field": "NGF",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #152",
             "alliances": [
@@ -555,7 +554,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2024-04-27T19:54:56-04:00"
         },
         {
             "id": 81659032,
@@ -575,7 +575,6 @@
             "scheduled": null,
             "started": null,
             "field": "Eaton",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #172",
             "alliances": [
@@ -623,7 +622,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2024-04-27T19:54:56-04:00"
         },
         {
             "id": 81659046,
@@ -643,7 +643,6 @@
             "scheduled": null,
             "started": null,
             "field": "NASA",
-            "session": 1,
             "scored": false,
             "name": "Qualifier #186",
             "alliances": [
@@ -691,7 +690,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2024-04-27T19:54:56-04:00"
         },
         {
             "id": 81659068,
@@ -711,7 +711,6 @@
             "scheduled": null,
             "started": null,
             "field": null,
-            "session": 1,
             "scored": false,
             "name": "R16 #3-1",
             "alliances": [
@@ -759,7 +758,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "updated_at": "2024-04-27T19:54:56-04:00"
         }
     ]
 }


### PR DESCRIPTION
This PR updates the `MatchModel` to use the new RobotEvents match pull scheme.

1. They removed the `session` key from the scheme. The old model was still trying to decode it but it does not exist, resulting in the throws and failed API pulls. This is now fixed by removing the `session` member property from `MatchModel` since it is not used anywhere anyway.
2. They have added the new `updated_at` key to indicate the last update time of the pulled match data. This PR adds the `lastUpdated` optional member property to store this information as well.

By updating to this scheme, this PR fixes the error encountered when getting all match lists from the RobotEvents API. It also refreshes `SiegeNationalsMatchlist.json` and `SiegeWorldsMatchlist.json` for future testing.